### PR TITLE
add elite vehicles extensions

### DIFF
--- a/classnames.sqf
+++ b/classnames.sqf
@@ -177,7 +177,7 @@ squads = [
 uavs = [ "B_UAV_01_F","B_UAV_02_F","B_UAV_02_CAS_F","B_UGV_01_F","B_UGV_01_rcws_F" ];
 
 // Vehicles unlocked through military base control. The game will pick which base unlocks which at the start of each new campaign.
-elite_vehicles = ["B_UGV_01_rcws_F","Steve_MBT_Kuma","B_MBT_01_TUSK_F","Burnes_FV4034_01","B_MBT_01_arty_F","B_MBT_01_mlrs_F","B_Heli_Attack_01_F","RHS_AH1Z_wd_GS","H_RAH66","RHS_AH64D_wd","B_Plane_CAS_01_F","JS_JC_FA18E","JS_JC_FA18F","B_UAV_02_F","B_UAV_02_CAS_F","greuh_pandur_wdld","RHS_M2A3_BUSKIII_wd","usaf_f22","USAF_F35A", "rhsusf_m1a2sep1tuskiid_usarmy"];
+elite_vehicles = ["B_UGV_01_rcws_F","B_MBT_01_TUSK_F","B_MBT_01_arty_F","B_MBT_01_mlrs_F","B_Heli_Attack_01_F","B_Plane_CAS_01_F","B_UAV_02_F","B_UAV_02_CAS_F"];
 
 // Everything the AI troups should be able to resupply from
 ai_resupply_sources = [ Respawn_truck_typename, huron_typename, Arsenal_typename, "B_Slingload_01_Ammo_F", "B_APC_Tracked_01_CRV_F", "B_Truck_01_ammo_F", "JNS_Skycrane_Pod_Ammo_BLU_Black" ];
@@ -336,7 +336,7 @@ GRLIB_blacklisted_from_arsenal = [
 
 
 
-
+elite_vehicles = elite_vehicles + elite_vehicles_extension;
 infantry_units = infantry_units + infantry_units_extension;
 light_vehicles = light_vehicles + light_vehicles_extension;
 heavy_vehicles = heavy_vehicles + heavy_vehicles_extension;

--- a/classnames_extension.sqf
+++ b/classnames_extension.sqf
@@ -97,3 +97,18 @@ support_vehicles_extension = [
 ["JNS_Skycrane_Pod_Repair_BLU_Black",5,0,0],
 ["JNS_Skycrane_Pod_Transport_BLU_Black",5,0,0]
 ];
+
+elite_vehicles_extension = [
+"Steve_MBT_Kuma",
+"Burnes_FV4034_01",
+"RHS_AH1Z_wd_GS",
+"H_RAH66",
+"RHS_AH64D_wd",
+"JS_JC_FA18E",
+"JS_JC_FA18F",
+"greuh_pandur_wdld",
+"RHS_M2A3_BUSKIII_wd",
+"usaf_f22",
+"USAF_F35A",
+"rhsusf_m1a2sep1tuskiid_usarmy"
+];


### PR DESCRIPTION
...same as logic in your mission. Stock vehicles goes to classnames, mods-etc goes to extensions for easier mod management.
Btw, what is H_RAH66? There is RAH-66 commanche in A3, but it's classname is "B_Heli_Attack_01_F". 
